### PR TITLE
Change direction of start now button

### DIFF
--- a/app/views/pages/_home-banner.html.erb
+++ b/app/views/pages/_home-banner.html.erb
@@ -1,6 +1,6 @@
 <div class="banner">
 
-     <%= link_to "Start now", new_user_session_path, class: "btn btn-lg btn-primary"  %>
+     <%= link_to "Start now", my_providers_path, class: "btn btn-lg btn-primary"  %>
 
     <div class="banner-content text-left">
       <h1>The future of moving is here.</h1>


### PR DESCRIPTION
Changed:
- Start now button leads you to the dashboard IF you are logged in. 
- If not logged in -> log in.

Why the change?
Otherwise the start button led you to the dashboard with alert "you are already logged in" -> not so nice.

How to check?
- Click on start now when not logged in, then when logged in :)