### PR TITLE
Hide categories without search results

### DIFF
--- a/app/views/providers/index.html.erb
+++ b/app/views/providers/index.html.erb
@@ -11,7 +11,9 @@
 
   <% Provider::CATEGORY.each do |cat_name| %>
     <% contents = @providers.filter { |prov| prov.category == cat_name } %>
+    <% unless contents.empty? %>
     <%= render "category", name: cat_name, providers: contents, selected_ids: @selected_ids, icons: @icons %>
+    <% end %>
   <% end %>
 
   <div class="fixed">


### PR DESCRIPTION
Implemented:
- If there is no search result in a category, the category is hidden.

Test:
- Search for any specific provider, the rest should be hidden. 