### PR TITLE
Fixed the redirection from My dashboard

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -12,7 +12,7 @@
     <ul class="d-flex align-items-center navbar-nav mr-auto">
       <% if user_signed_in? %>
         <li class="nav-item active">
-          <%= link_to "My Dashboard", my_providers_path, class: "nav-wagon-link " %>
+          <%= link_to "My Dashboard", my_providers_path(checked:"1"), class: "nav-wagon-link " %>
         </li>
         <li class="nav-item">
           <%= link_to "Plan your move", new_move_path, class: "nav-wagon-link " %>


### PR DESCRIPTION
Fixed the redirection from My dashboard

When you are on the providers index page and you click on My dashboard it redirects you to the my providers index page with the third tab open