### PR TITLE
Checkboxes in tab labels added

### DIFF
--- a/app/assets/stylesheets/components/_cards-my-providers.scss
+++ b/app/assets/stylesheets/components/_cards-my-providers.scss
@@ -4,7 +4,7 @@
 
 .tabs-v label {position:relative;
   order:1;
-  width:200px;
+  width:220px;
   padding:15px 0 20px;
   background-color:transparent;
   margin-bottom:0;

--- a/app/controllers/my_providers_controller.rb
+++ b/app/controllers/my_providers_controller.rb
@@ -71,7 +71,7 @@ class MyProvidersController < ApplicationController
   # Maybe we should move it to updates controller, just need to figure out how
   # Checks if all updates are in the new (index 0) status
   def updates_new?
-    @updates.all? { |update| update.update_status == Update::STATUS[0] }
+    @updates.nil? || @updates.all? { |update| update.update_status == Update::STATUS[0] }
   end
   helper_method :updates_new?
 

--- a/app/views/my_providers/_move-info.html.erb
+++ b/app/views/my_providers/_move-info.html.erb
@@ -1,7 +1,7 @@
 <div class="move-info pl-2">
   <div class="calendar-info">
     <p>
-      <h2> Your move information: </h2>
+      <h3> Your move information: </h3>
       <strong>Address</strong>: <%= @move.address_string %><br>
       <strong>Date</strong>: <%= @move.moving_date %>
     </p>

--- a/app/views/my_providers/_move-updates.html.erb
+++ b/app/views/my_providers/_move-updates.html.erb
@@ -13,7 +13,7 @@
         <% if update.pdf.present? %>
           <p> 
             <%= link_to pdf_path("#{update.pdf.uuid}.pdf") do %>
-              Get the paper <%= icon("far", "envelope", class: "text-info") %>
+              Get the paper <%= icon("far", "envelope", class: "text-success") %>
             <% end %>
           </p>
         <% end %>
@@ -26,7 +26,7 @@
           <% when "pending" %>
            <%= icon("fas", "paper-plane", class: "text-info") %>
           <% when "confirmed" %>
-           <%= icon("fas", "thumbs-up", class: "text-info") %>
+           <%= icon("fas", "thumbs-up", class: "text-success") %>
           <% when "declined" %>
            <%= icon("fas", "thumbs-down", class: "text-info") %>
           <% end %>

--- a/app/views/my_providers/_my_pro-section.html.erb
+++ b/app/views/my_providers/_my_pro-section.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-5">
+<div class="mt-3 mb-5">
   <%# If we haven't sent the updates (they don't exist or all new), we show all: %>
   <% if updates_new? %>
     <% collapse = "" %>

--- a/app/views/my_providers/_new-layout.html.erb
+++ b/app/views/my_providers/_new-layout.html.erb
@@ -5,7 +5,12 @@
 
 	<input type="radio" name="tabs-v" id="tab1-v" checked="<%= checked_not_present %>">
 	<label for="tab1-v">
-		<p> 1 . Plan your move </p>
+		<p> 
+			1 . Plan your move 
+			<% if @move.present? %>
+				<%= icon("fas", "check", class: "text-success") %>
+			<% end %>
+		</p>
 	</label>
 	<div class="tab-content">
 		<div>
@@ -22,7 +27,12 @@
 
 	<input type="radio" name="tabs-v" id="tab2-v">
 	<label for="tab2-v">
-		<p> 2 . Add New Providers </p>
+		<p>
+			2 . Add New Providers
+			<% if @my_providers.present? %>
+				<%= icon("fas", "check", class: "text-success") %>
+			<% end %>
+		</p>
 	</label>
 	<div class="tab-content">
 		<div>
@@ -39,7 +49,12 @@
       
 	<input type="radio" name="tabs-v" id="tab3-v" <%= checked %>>
 	<label for="tab3-v">
-		<p>3 . Confirm & Send</p>
+		<p>
+			3 . Confirm & Send
+			<% unless updates_new? %>
+				<%= icon("fas", "check", class: "text-success") %>
+			<% end %>
+		</p>
 	</label>
 	<div class="tab-content">
 		<div>

--- a/app/views/my_providers/index.html.erb
+++ b/app/views/my_providers/index.html.erb
@@ -4,36 +4,35 @@
 
 <div class="container my-5 block">
   <%= render "new-layout" %>
-</div>
 
-<div class="container my-3 block">
-  <h2> Overview </h2>
-  <hr>
+  <div class="card bg-white rounded-0 border-light mt-3 block p-5">
+    <h2> Overview </h2>
+    <hr>
 
-	<%# Completely new user will see this: %>
-  <% if @my_providers.empty? && @move.nil? %>
-    <p> Nothing here yet. <br>Start by <%= link_to "setting your move date and address", new_move_path(@my_provider) %>. </p>
-  <% end %>
-
-  <%# If we have the move information, we show the move block: %>
-  <% unless @move.nil? %>
-    <%= render "move-info" %>
-    <%# If we already have some updates planned, we also show the updates block: %>
-    <% unless @updates.empty? || updates_new? %>
-      <h3> Requests sent to providers </h3>
-      <%= render "move-updates" %>
+    <%# Completely new user will see this: %>
+    <% if @my_providers.empty? && @move.nil? %>
+      <p> Nothing here yet. <br>Start by <%= link_to "setting your move date and address", new_move_path(@my_provider) %>. </p>
     <% end %>
-  <% end %>
 
-  <%# If we have any providers selections, we show them: %>
-  <% unless @my_providers.empty? %>
-    <hr>
-    <%= render "my_pro-section" %>
-  <% end %>
+    <%# If we have the move information, we show the move block: %>
+    <% unless @move.nil? %>
+      <%= render "move-info" %>
+      <%# If we already have some updates planned, we also show the updates block: %>
+      <% unless @updates.empty? || updates_new? %>
+        <h3> Requests sent to providers </h3>
+        <%= render "move-updates" %>
+      <% end %>
+    <% end %>
 
-  <%# A message in case the move is created, but providers are not selected: %>
-  <% if @move.present? && @my_providers.empty? && updates_new? %>
-    <hr>
-    <p> <%= link_to "Select the providers", providers_path %> which you'd like to inform about your new address. </p>
-  <% end %>
+    <%# If we have any providers selections, we show them: %>
+    <% unless @my_providers.empty? %>
+      <%= render "my_pro-section" %>
+    <% end %>
+
+    <%# A message in case the move is created, but providers are not selected: %>
+    <% if @move.present? && @my_providers.empty? && updates_new? %>
+      <hr>
+      <p> <%= link_to "Select the providers", providers_path %> which you'd like to inform about your new address. </p>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Now the tabs have checkboxes in them:
- If move exists -- 1st tab checked
- If provider selection list not empty -- 2nd tab checked
- If updates exist & all of them have the status "pending" (i.e. sent) -- 3rd tab checked

Also, the Move Overview is shown as a card now, added this with Miluska.
+ Added some color to the status icons